### PR TITLE
Fix missing all pulses to max ~30Hz with a comment

### DIFF
--- a/OpticalEncoder/OpticalEncoder.h
+++ b/OpticalEncoder/OpticalEncoder.h
@@ -42,17 +42,20 @@ void OpticalEncoder::setup(uint8_t pinNr, void (*ISR_callback)(void), int value,
   #endif
 }
 
+const unsigned long INTERVAL_TIME = 3; // If you get max 30Hz, change this number
+                                       // If you have a HAL encoder, just change to 0
+
 inline void OpticalEncoder::handleInterrupt(void)
 {
   unsigned long currmillis = millis();
-  if (currmillis - prevmillis > 3) {
+  if (currmillis - prevmillis >= 3) {
     if(_movingForward) {
       _encoder0Pos++;
     } else {
       _encoder0Pos--;
     }
+    prevmillis = currmillis;
   }
-  prevmillis = currmillis;
 }
 
 


### PR DESCRIPTION
Originally when the encoder went too fast (>30Hz), the prevmillis would be updated on every interrupt, even if the pulse was too soon after the previous one. Then the speed would stay at 0Hz.

New: the prevmillis is only updated when a pulse is counted. This will cap the rate at 30Hz, but at least show some data. 

Also added comment where to look/change when you want to use a higher rate encoder.